### PR TITLE
getCMSValidator compatibility

### DIFF
--- a/code/IconField.php
+++ b/code/IconField.php
@@ -35,6 +35,8 @@ class IconField extends OptionsetField
             $this->setFolderName($sourceFolder);
         }
         parent::__construct($name, $title, []);
+        
+        $this->setSourceIcons();
     }
 
     /**
@@ -123,7 +125,6 @@ class IconField extends OptionsetField
     public function Field($properties = [])
     {
         Requirements::css('plasticstudio/iconfield:css/IconField.css');
-        $this->setSourceIcons();
         $source = $this->getSource();
         $options = [];
 


### PR DESCRIPTION
If a data object had a `getCMSValidator` method, validation for this field would always fail with the ` x is not a valid option`. 
 This is because source was only set when displaying the field, this change allows the source to be available in all contexts.